### PR TITLE
Enable working with `node build/index.js`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+build
+
 # Logs
 logs
 *.log

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,38 @@
+# Development
+
+## Running with Inspector
+
+Run the MCP Inspector:
+
+```sh
+npm run inspector
+```
+
+## Running via Stdio
+
+Run the server and send JSON-RPC requests via stdin:
+
+```sh
+npm run dev
+
+# OR
+
+npm run build && node ./build/index.js
+```
+
+### Input Examples
+
+1. **ping**
+    ```json
+    {"jsonrpc":"2.0", "id":1, "method":"ping"}
+    ```
+
+2. **initialize**
+    ```json
+    {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{"roots":{"listChanged":true}},"clientInfo":{"name":"local","version":"0.0.1"}}}
+    ```
+
+3. **tools/list**
+    ```json
+    {"jsonrpc": "2.0", "id": 1, "method": "tools/list"}
+    ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "zod": "^3.25.76"
       },
       "devDependencies": {
+        "@types/node": "^24.2.1",
         "tsx": "^4.20.3"
       }
     },
@@ -52,6 +53,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.2.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.1.tgz",
+      "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~7.10.0"
       }
     },
     "node_modules/accepts": {
@@ -1013,6 +1023,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "dev": true
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "TBD",
   "main": "index.js",
   "scripts": {
+    "build": "tsc",
     "dev": "tsx src/index.ts",
     "inspector": "npx @modelcontextprotocol/inspector tsx src/index.ts"
   },
@@ -13,6 +14,7 @@
     "zod": "^3.25.76"
   },
   "devDependencies": {
+    "@types/node": "^24.2.1",
     "tsx": "^4.20.3"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "nodenext",
+    "outDir": "./build",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
To enable running with Docker("node"), added code to compile files to javascript.

I'm planning to write a Dockerfile like below in next PR (though maybe more rough)
https://github.com/docker/hub-mcp/blob/main/Dockerfile