### PR TITLE
Implement get_alert_logs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,10 +33,15 @@ src/
 
 Each tool follows this structure:
 1. Refer https://mackerel.io/api-docs/ for API documentation
-2. Define Zod schema for input validation
+2. Define Zod schema for input validation that includes ALL documented parameters
 3. Implement tool callback that builds URLSearchParams for API calls
 4. Use `buildToolResponse()` utility for consistent response formatting and error handling
 5. Tools are registered in `src/index.ts`
+6. Tests are written next to the tool implementation
+
+Notes:
+* About API Documentation Reference:
+  When viewing API documentation, first visit https://mackerel.io/api-docs/ and follow the endpoint links listed there to check the detailed specifications for the target endpoint.
 
 ### Testing
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -71,4 +71,25 @@ export class MackerelClient {
   async getAlert(alertId: string) {
     return this.request<{ alert: any }>("GET", `/api/v0/alerts/${alertId}`);
   }
+
+  // GET /api/v0/alerts/{alertId}/logs
+  async getAlertLogs(
+    alertId: string,
+    nextId: string | undefined,
+    limit: number | undefined,
+  ): Promise<{ logs: any[]; nextId?: string }> {
+    const searchParams = new URLSearchParams();
+    if (nextId) {
+      searchParams.append("nextId", nextId);
+    }
+    if (limit !== undefined) {
+      searchParams.append("limit", limit.toString());
+    }
+
+    return this.request<{ logs: any[]; nextId?: string }>(
+      "GET",
+      `/api/v0/alerts/${alertId}/logs`,
+      { searchParams },
+    );
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,17 @@ async function main() {
     alertTool.getAlert,
   );
 
+  server.registerTool(
+    "get_alert_logs",
+    {
+      title: "Get Alert Logs",
+      // TODO: enhance description
+      description: "Retrieve logs for a specific alert by ID from Mackerel",
+      inputSchema: AlertTool.GetAlertLogsToolInput.shape,
+    },
+    alertTool.getAlertLogs,
+  );
+
   const transport = new StdioServerTransport();
   await server.connect(transport);
   console.error("Mackerel MCP Server running on stdio");

--- a/src/tools/alertTool.ts
+++ b/src/tools/alertTool.ts
@@ -50,4 +50,33 @@ export class AlertTool {
       async () => await this.mackerelClient.getAlert(alertId),
     );
   };
+
+  static GetAlertLogsToolInput = z.object({
+    alertId: z.string().describe("The ID of the alert to retrieve logs for"),
+    nextId: z
+      .string()
+      .optional()
+      .describe(
+        "If specified, alert logs older than the specified are retrieved",
+      ),
+    limit: z
+      .number()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe(
+        "The maximum number of alert logs to retrieve. When omitted, up to 100 logs are retrieved. The most that can be specified is 100",
+      ),
+  });
+
+  getAlertLogs = async ({
+    alertId,
+    nextId,
+    limit,
+  }: z.infer<typeof AlertTool.GetAlertLogsToolInput>) => {
+    return await buildToolResponse(
+      async () =>
+        await this.mackerelClient.getAlertLogs(alertId, nextId, limit),
+    );
+  };
 }


### PR DESCRIPTION
Implement "get_alert_logs" tool for https://mackerel.io/api-docs/entry/alerts#logs