### PR TITLE
Enable working npx

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   },
   "description": "A Model Context Protocol server for interacting with Mackerel",
   "main": "build/index.js",
+  "bin": {
+    "mcp-server": "build/index.js"
+  },
   "type": "module",
   "scripts": {
     "build": "tsdown",

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -5,4 +5,7 @@ export default defineConfig({
   outDir: "build",
   clean: true,
   minify: true,
+  banner: {
+    js: "#!/usr/bin/env node",
+  },
 });


### PR DESCRIPTION
Should work with `npx @mackerel/mcp-server` after publishing.

I checked `MACKEREL_API_KEY=test npx . mcp-server` works locally.