### PR TITLE
Push to GHCR on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,9 +8,10 @@ on:
 permissions:
   id-token: write  # Required for OIDC
   contents: read
+  packages: write
 
 jobs:
-  publish:
+  publish-npm:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -24,3 +25,34 @@ jobs:
       - run: npm run build --if-present
       - run: npm test
       - run: npm publish
+
+  publish-docker:
+    needs: publish-npm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get version
+        id: get_version
+        run: |
+          VERSION=$(npm pkg get version | tr -d '"')
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: |
+            linux/amd64
+            linux/arm64
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/mcp-server:latest
+            ghcr.io/${{ github.repository_owner }}/mcp-server:${{ steps.get_version.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 COPY package.json .
 COPY package-lock.json .
 COPY tsconfig.json .
+COPY tsdown.config.ts .
 
 RUN npm ci
 


### PR DESCRIPTION
Add workflow to push Docker image to GHCR.

I checked this workflow works by creating a temporary workflow to push the image. 
You can pull the image at `ghcr.io/mackerelio-labs/mcp-server:0.0.1-dev` now.
c.f. https://github.com/mackerelio-labs/mcp-server/actions/runs/17152110198/job/48660525714