### PR TITLE
fix npm publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,10 +17,9 @@ jobs:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
 
-      # Ensure npm 11.5.1 or later is installed
-      - name: Update npm
-        run: npm install -g npm@latest
       - run: npm ci
       - run: npm run build --if-present
       - run: npm test


### PR DESCRIPTION
The command `npm install -g npm@latest` was failing. Instead, I changed it to explicitly specify the Node.js version using setup-node.

https://github.com/mackerelio-labs/mcp-server/actions/runs/17816644276/job/50651041051