### PR TITLE
add step to install latest npm version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,12 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Install latest npm
+        run: |
+          echo "Current npm version: $(npm -v)"
+          npm install -g npm@latest
+          echo "Updated npm version: $(npm -v)"
+
       - run: npm ci
       - run: npm run build --if-present
       - run: npm test


### PR DESCRIPTION
After removing the install command in #37, releases now fail with `npm publish`. I want to check if the npm version is the cause by adding a command to display the npm version.