### PR TITLE
Add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
     "LICENSE"
   ],
   "types": "build/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mackerelio-labs/mcp-server.git"
+  },
   "bugs": {
     "url": "https://github.com/mackerelio-labs/mcp-server/issues"
   },


### PR DESCRIPTION
The npm publish command fails because the repository.url is empty. To resolve this issue, I added the repository field to package.json.

https://github.com/mackerelio-labs/mcp-server/actions/runs/17846126122/job/50745646580