### PR TITLE
implements a new get_trace tool for retrieving distributed tracing data from Mackerel

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,4 @@ The MCP server can be run either via Docker or npx.
 * `get_service_metrics` - Retrieve metrics data for a specific service.
 * `list_monitors` - Retrieve monitor configurations.
 * `get_monitor` - Retrieve a specific monitor configuration.
+* `get_trace` - Retrieve trace data by trace ID for distributed tracing analysis.

--- a/src/client.ts
+++ b/src/client.ts
@@ -330,4 +330,9 @@ export class MackerelClient {
       `/api/v0/monitors/${monitorId}`,
     );
   }
+
+  // GET /api/v0/traces/{traceId}
+  async getTrace(traceId: string): Promise<{ spans: any[] }> {
+    return this.request<{ spans: any[] }>("GET", `/api/v0/traces/${traceId}`);
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -383,7 +383,7 @@ get_trace(traceId="abc123def456", errorSpansOnly=true)
 
 ### Identify bottlenecks (spans > 100ms)
 \`\`\`
-get_trace(traceId="abc123def456", filterByDuration=100)
+get_trace(traceId="abc123def456", duration=100)
 \`\`\`
 
 ### Detailed analysis with attributes

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { DashboardTool } from "./tools/dashboardTool.js";
 import { MonitorTool } from "./tools/monitorTool.js";
 import { HostTool } from "./tools/hostTool.js";
 import { ServiceTool } from "./tools/serviceTool.js";
+import { TraceTool } from "./tools/traceTool.js";
 import { MackerelClient } from "./client.js";
 import { ServiceMetricsTool } from "./tools/serviceMetricsTool.js";
 import { HostMetricsTool } from "./tools/hostMetricsTool.js";
@@ -20,6 +21,7 @@ async function main() {
   const hostMetricsTool = new HostMetricsTool(mackerelClient);
   const serviceTool = new ServiceTool(mackerelClient);
   const serviceMetricsTool = new ServiceMetricsTool(mackerelClient);
+  const traceTool = new TraceTool(mackerelClient);
 
   // Create an MCP server
   const server = new McpServer({
@@ -353,6 +355,62 @@ get_monitor(monitorId="2cSZzK3XfmB")
       inputSchema: MonitorTool.GetMonitorToolInput.shape,
     },
     monitorTool.getMonitor,
+  );
+
+  server.registerTool(
+    "get_trace",
+    {
+      title: "Get Trace",
+      description: `Retrieve trace data by trace ID from Mackerel for distributed tracing analysis.
+
+🔍 USE THIS TOOL WHEN USERS:
+- Analyze performance bottlenecks in distributed systems
+- Investigate error propagation across microservices
+- Understand request flow and service dependencies
+- Debug latency issues and identify slow operations
+- Generate documentation of system architecture from trace data
+
+## Key Features:
+- **Smart filtering**: Automatically prioritizes error spans and high-latency operations
+- **Response optimization**: Reduces data size to fit within token limits while preserving critical information
+- **Interactive drill-down**: Support for progressive analysis with multiple queries
+
+<examples>
+### Basic trace retrieval (optimized for analysis)
+\`\`\`
+get_trace(traceId="abc123def456")
+\`\`\`
+
+### Focus on errors only
+\`\`\`
+get_trace(traceId="abc123def456", errorSpansOnly=true)
+\`\`\`
+
+### Identify bottlenecks (spans > 100ms)
+\`\`\`
+get_trace(traceId="abc123def456", filterByDuration=100)
+\`\`\`
+
+### Detailed analysis with attributes
+\`\`\`
+get_trace(traceId="abc123def456", includeAttributes=true, maxSpans=50)
+\`\`\`
+
+### Minimal view for overview
+\`\`\`
+get_trace(traceId="abc123def456", includeEvents=false, maxSpans=20)
+\`\`\`
+</examples>
+
+## Use Cases:
+- **Error Analysis**: Quickly identify which service caused an error and how it propagated
+- **Performance Investigation**: Find the slowest operations in a transaction
+- **Service Dependencies**: Understand how services interact in complex workflows
+- **Documentation**: Generate dynamic documentation of system architecture
+`,
+      inputSchema: TraceTool.GetTraceToolInput.shape,
+    },
+    traceTool.getTrace,
   );
 
   const transport = new StdioServerTransport();

--- a/src/index.ts
+++ b/src/index.ts
@@ -370,8 +370,7 @@ get_monitor(monitorId="2cSZzK3XfmB")
 - Debug latency issues and identify slow operations
 - Generate documentation of system architecture from trace data
 
-## Key Features:
-- **Smart filtering**: Automatically prioritizes error spans and high-latency operations
+🔑 KEY FEATURES:
 - **Pagination support**: Navigate through large traces with limit/offset parameters
 - **Response optimization**: Reduces data size while preserving critical information
 - **Interactive drill-down**: Support for progressive analysis with multiple queries

--- a/src/index.ts
+++ b/src/index.ts
@@ -370,11 +370,6 @@ get_monitor(monitorId="2cSZzK3XfmB")
 - Debug latency issues and identify slow operations
 - Generate documentation of system architecture from trace data
 
-🔑 KEY FEATURES:
-- **Pagination support**: Navigate through large traces with limit/offset parameters
-- **Response optimization**: Reduces data size while preserving critical information
-- **Interactive drill-down**: Support for progressive analysis with multiple queries
-
 <examples>
 ### Basic trace retrieval (first page)
 \`\`\`

--- a/src/index.ts
+++ b/src/index.ts
@@ -372,11 +372,12 @@ get_monitor(monitorId="2cSZzK3XfmB")
 
 ## Key Features:
 - **Smart filtering**: Automatically prioritizes error spans and high-latency operations
-- **Response optimization**: Reduces data size to fit within token limits while preserving critical information
+- **Pagination support**: Navigate through large traces with limit/offset parameters
+- **Response optimization**: Reduces data size while preserving critical information
 - **Interactive drill-down**: Support for progressive analysis with multiple queries
 
 <examples>
-### Basic trace retrieval (optimized for analysis)
+### Basic trace retrieval (first page)
 \`\`\`
 get_trace(traceId="abc123def456")
 \`\`\`
@@ -393,12 +394,23 @@ get_trace(traceId="abc123def456", filterByDuration=100)
 
 ### Detailed analysis with attributes
 \`\`\`
-get_trace(traceId="abc123def456", includeAttributes=true, maxSpans=50)
+get_trace(traceId="abc123def456", includeAttributes=true, limit=50)
 \`\`\`
 
 ### Minimal view for overview
 \`\`\`
-get_trace(traceId="abc123def456", includeEvents=false, maxSpans=20)
+get_trace(traceId="abc123def456", includeEvents=false, limit=10)
+\`\`\`
+
+### Pagination through large traces
+\`\`\`
+get_trace(traceId="abc123def456", limit=20, offset=0)  # First page
+get_trace(traceId="abc123def456", limit=20, offset=20) # Second page
+\`\`\`
+
+### Combined filtering and pagination
+\`\`\`
+get_trace(traceId="abc123def456", errorSpansOnly=true, limit=10, offset=0)
 \`\`\`
 </examples>
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -407,12 +407,6 @@ get_trace(traceId="abc123def456", limit=20, offset=20) # Second page
 get_trace(traceId="abc123def456", errorSpansOnly=true, limit=10, offset=0)
 \`\`\`
 </examples>
-
-## Use Cases:
-- **Error Analysis**: Quickly identify which service caused an error and how it propagated
-- **Performance Investigation**: Find the slowest operations in a transaction
-- **Service Dependencies**: Understand how services interact in complex workflows
-- **Documentation**: Generate dynamic documentation of system architecture
 `,
       inputSchema: TraceTool.GetTraceToolInput.shape,
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -381,7 +381,7 @@ get_trace(traceId="abc123def456")
 get_trace(traceId="abc123def456", errorSpansOnly=true)
 \`\`\`
 
-### Identify bottlenecks (spans > 100ms)
+### Filter spans with duration over 100ms
 \`\`\`
 get_trace(traceId="abc123def456", duration=100)
 \`\`\`

--- a/src/tools/traceTool.test.ts
+++ b/src/tools/traceTool.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect } from "vitest";
+import { setupClient } from "../__tests__/setupClient.js";
+import { setupServer } from "../__tests__/setupServer.js";
+import { TraceTool } from "./traceTool.js";
+import { mswServer } from "../mocks/server.js";
+import { HttpResponse, http } from "msw";
+import { MackerelClient } from "../client.js";
+import { MACKEREL_BASE_URL } from "../__tests__/mackerelClient.js";
+
+describe("Trace Tool", () => {
+  const mackerelClient = new MackerelClient(MACKEREL_BASE_URL, "test-api");
+  const traceTool = new TraceTool(mackerelClient);
+
+  const mockTraceData = {
+    spans: [
+      {
+        traceId: "trace123",
+        spanId: "span1",
+        name: "HTTP GET /api/users",
+        startTime: 1600000000000,
+        endTime: 1600000000500,
+        attributes: {
+          "http.method": "GET",
+          "http.url": "/api/users",
+          "http.status_code": 200,
+        },
+        events: [
+          {
+            name: "request.start",
+            timestamp: 1600000000100,
+            attributes: { user_id: "12345" },
+          },
+        ],
+        status: { code: "OK" },
+        resource: { service: "user-service" },
+        scope: { name: "http-tracer" },
+      },
+      {
+        traceId: "trace123",
+        spanId: "span2",
+        name: "Database Query",
+        startTime: 1600000000200,
+        endTime: 1600000000800,
+        attributes: {
+          "db.statement": "SELECT * FROM users",
+          "db.type": "postgresql",
+        },
+        events: [
+          {
+            name: "exception",
+            timestamp: 1600000000300,
+            attributes: {
+              "exception.type": "DatabaseError",
+              "exception.message": "Connection timeout",
+            },
+          },
+        ],
+        status: { code: "ERROR", message: "Database connection failed" },
+        resource: { service: "database-service" },
+        scope: { name: "db-tracer" },
+      },
+      {
+        traceId: "trace123",
+        spanId: "span3",
+        name: "Cache lookup",
+        startTime: 1600000000050,
+        endTime: 1600000000080,
+        attributes: {
+          "cache.key": "user:12345",
+        },
+        events: [],
+        status: { code: "OK" },
+        resource: { service: "cache-service" },
+        scope: { name: "cache-tracer" },
+      },
+    ],
+  };
+
+  it("should retrieve and optimize trace data with default settings", async () => {
+    mswServer.use(
+      http.get(MACKEREL_BASE_URL + "/api/v0/traces/trace123", () => {
+        return HttpResponse.json(mockTraceData);
+      }),
+    );
+
+    const server = setupServer(
+      "get_trace",
+      { inputSchema: TraceTool.GetTraceToolInput.shape },
+      traceTool.getTrace,
+    );
+    const { client } = await setupClient(server);
+
+    const result = await client.callTool({
+      name: "get_trace",
+      arguments: {
+        traceId: "trace123",
+      },
+    });
+
+    const responseData = JSON.parse(result.content[0].text as string);
+
+    expect(responseData.traceId).toBe("trace123");
+    expect(responseData.summary.totalSpans).toBe(3);
+    expect(responseData.summary.returnedSpans).toBe(3);
+    expect(responseData.summary.hasErrors).toBe(true);
+    expect(responseData.spans).toHaveLength(3);
+
+    // Check optimization: should include events but not attributes by default
+    const spanWithEvents = responseData.spans.find(
+      (s: any) => s.spanId === "span2",
+    );
+    expect(spanWithEvents.events).toBeDefined();
+    expect(spanWithEvents.attributes).toBeUndefined();
+    expect(spanWithEvents.hasError).toBe(true);
+    expect(spanWithEvents.duration).toBe(600);
+  });
+
+  it("should filter spans by duration", async () => {
+    mswServer.use(
+      http.get(MACKEREL_BASE_URL + "/api/v0/traces/trace123", () => {
+        return HttpResponse.json(mockTraceData);
+      }),
+    );
+
+    const server = setupServer(
+      "get_trace",
+      { inputSchema: TraceTool.GetTraceToolInput.shape },
+      traceTool.getTrace,
+    );
+    const { client } = await setupClient(server);
+
+    const result = await client.callTool({
+      name: "get_trace",
+      arguments: {
+        traceId: "trace123",
+        filterByDuration: 400,
+      },
+    });
+
+    const responseData = JSON.parse(result.content[0].text as string);
+
+    expect(responseData.summary.totalSpans).toBe(3);
+    expect(responseData.summary.returnedSpans).toBe(2); // Only spans with duration >= 400ms
+    expect(responseData.spans).toHaveLength(2);
+
+    // Should include the 500ms and 600ms spans, but not the 30ms cache span
+    const spanIds = responseData.spans.map((s: any) => s.spanId);
+    expect(spanIds).toContain("span1");
+    expect(spanIds).toContain("span2");
+    expect(spanIds).not.toContain("span3");
+  });
+
+  it("should return only error spans when errorSpansOnly is true", async () => {
+    mswServer.use(
+      http.get(MACKEREL_BASE_URL + "/api/v0/traces/trace123", () => {
+        return HttpResponse.json(mockTraceData);
+      }),
+    );
+
+    const server = setupServer(
+      "get_trace",
+      { inputSchema: TraceTool.GetTraceToolInput.shape },
+      traceTool.getTrace,
+    );
+    const { client } = await setupClient(server);
+
+    const result = await client.callTool({
+      name: "get_trace",
+      arguments: {
+        traceId: "trace123",
+        errorSpansOnly: true,
+      },
+    });
+
+    const responseData = JSON.parse(result.content[0].text as string);
+
+    expect(responseData.summary.totalSpans).toBe(3);
+    expect(responseData.summary.returnedSpans).toBe(1); // Only the error span
+    expect(responseData.spans).toHaveLength(1);
+    expect(responseData.spans[0].spanId).toBe("span2");
+    expect(responseData.spans[0].hasError).toBe(true);
+  });
+
+  it("should include attributes when requested", async () => {
+    mswServer.use(
+      http.get(MACKEREL_BASE_URL + "/api/v0/traces/trace123", () => {
+        return HttpResponse.json(mockTraceData);
+      }),
+    );
+
+    const server = setupServer(
+      "get_trace",
+      { inputSchema: TraceTool.GetTraceToolInput.shape },
+      traceTool.getTrace,
+    );
+    const { client } = await setupClient(server);
+
+    const result = await client.callTool({
+      name: "get_trace",
+      arguments: {
+        traceId: "trace123",
+        includeAttributes: true,
+      },
+    });
+
+    const responseData = JSON.parse(result.content[0].text as string);
+
+    const spanWithAttributes = responseData.spans.find(
+      (s: any) => s.spanId === "span1",
+    );
+    expect(spanWithAttributes.attributes).toBeDefined();
+    expect(spanWithAttributes.attributes["http.method"]).toBe("GET");
+  });
+
+  it("should exclude events when requested", async () => {
+    mswServer.use(
+      http.get(MACKEREL_BASE_URL + "/api/v0/traces/trace123", () => {
+        return HttpResponse.json(mockTraceData);
+      }),
+    );
+
+    const server = setupServer(
+      "get_trace",
+      { inputSchema: TraceTool.GetTraceToolInput.shape },
+      traceTool.getTrace,
+    );
+    const { client } = await setupClient(server);
+
+    const result = await client.callTool({
+      name: "get_trace",
+      arguments: {
+        traceId: "trace123",
+        includeEvents: false,
+      },
+    });
+
+    const responseData = JSON.parse(result.content[0].text as string);
+
+    responseData.spans.forEach((span: any) => {
+      expect(span.events).toBeUndefined();
+    });
+  });
+
+  it("should respect maxSpans limit", async () => {
+    mswServer.use(
+      http.get(MACKEREL_BASE_URL + "/api/v0/traces/trace123", () => {
+        return HttpResponse.json(mockTraceData);
+      }),
+    );
+
+    const server = setupServer(
+      "get_trace",
+      { inputSchema: TraceTool.GetTraceToolInput.shape },
+      traceTool.getTrace,
+    );
+    const { client } = await setupClient(server);
+
+    const result = await client.callTool({
+      name: "get_trace",
+      arguments: {
+        traceId: "trace123",
+        maxSpans: 2,
+      },
+    });
+
+    const responseData = JSON.parse(result.content[0].text as string);
+
+    expect(responseData.summary.totalSpans).toBe(3);
+    expect(responseData.summary.returnedSpans).toBe(2);
+    expect(responseData.spans).toHaveLength(2);
+
+    // Should prioritize error spans and then longest duration
+    expect(responseData.spans[0].hasError).toBe(true); // Error span first
+    expect(responseData.spans[0].spanId).toBe("span2");
+  });
+
+  it("should handle 404 error", async () => {
+    mswServer.use(
+      http.get(MACKEREL_BASE_URL + "/api/v0/traces/nonexistent", () => {
+        return HttpResponse.json({ error: "Trace not found" }, { status: 404 });
+      }),
+    );
+
+    const server = setupServer(
+      "get_trace",
+      { inputSchema: TraceTool.GetTraceToolInput.shape },
+      traceTool.getTrace,
+    );
+    const { client } = await setupClient(server);
+
+    const result = await client.callTool({
+      name: "get_trace",
+      arguments: {
+        traceId: "nonexistent",
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Mackerel API error: 404");
+  });
+});

--- a/src/tools/traceTool.test.ts
+++ b/src/tools/traceTool.test.ts
@@ -160,7 +160,7 @@ describe("Trace Tool", () => {
       name: "get_trace",
       arguments: {
         traceId: "trace123",
-        filterByDuration: 400,
+        duration: 400,
       },
     });
 
@@ -393,7 +393,7 @@ describe("Trace Tool", () => {
       name: "get_trace",
       arguments: {
         traceId: "trace123",
-        filterByDuration: 400,
+        duration: 400,
         limit: 1,
         offset: 0,
       },

--- a/src/tools/traceTool.test.ts
+++ b/src/tools/traceTool.test.ts
@@ -55,7 +55,7 @@ describe("Trace Tool", () => {
             },
           },
         ],
-        status: { code: "ERROR", message: "Database connection failed" },
+        status: { code: "ERROR (2)", message: "Database connection failed" },
         resource: { service: "database-service" },
         scope: { name: "db-tracer" },
       },

--- a/src/tools/traceTool.test.ts
+++ b/src/tools/traceTool.test.ts
@@ -100,9 +100,6 @@ describe("Trace Tool", () => {
     const responseData = JSON.parse(result.content[0].text as string);
 
     expect(responseData.traceId).toBe("trace123");
-    expect(responseData.summary.totalSpans).toBe(3);
-    expect(responseData.summary.filteredTotalSpans).toBe(3);
-    expect(responseData.summary.returnedSpans).toBe(3);
     expect(responseData.summary.hasErrors).toBe(true);
     expect(responseData.summary.pageInfo.totalPages).toBe(1);
     expect(responseData.summary.pageInfo.currentPage).toBe(1);
@@ -144,9 +141,6 @@ describe("Trace Tool", () => {
 
     const responseData = JSON.parse(result.content[0].text as string);
 
-    expect(responseData.summary.totalSpans).toBe(3);
-    expect(responseData.summary.filteredTotalSpans).toBe(2); // Only spans with duration >= 400ms
-    expect(responseData.summary.returnedSpans).toBe(2);
     expect(responseData.spans).toHaveLength(2);
 
     // Should include the 500ms and 600ms spans, but not the 30ms cache span
@@ -180,9 +174,6 @@ describe("Trace Tool", () => {
 
     const responseData = JSON.parse(result.content[0].text as string);
 
-    expect(responseData.summary.totalSpans).toBe(3);
-    expect(responseData.summary.filteredTotalSpans).toBe(1); // Only the error span after filtering
-    expect(responseData.summary.returnedSpans).toBe(1);
     expect(responseData.spans).toHaveLength(1);
     expect(responseData.spans[0].spanId).toBe("span2");
     expect(responseData.spans[0].hasError).toBe(true);
@@ -272,9 +263,6 @@ describe("Trace Tool", () => {
 
     const responseData = JSON.parse(result.content[0].text as string);
 
-    expect(responseData.summary.totalSpans).toBe(3);
-    expect(responseData.summary.filteredTotalSpans).toBe(3);
-    expect(responseData.summary.returnedSpans).toBe(2);
     expect(responseData.spans).toHaveLength(2);
     expect(responseData.summary.pageInfo.totalPages).toBe(2);
     expect(responseData.summary.pageInfo.currentPage).toBe(1);
@@ -312,9 +300,6 @@ describe("Trace Tool", () => {
 
     const responseData = JSON.parse(result.content[0].text as string);
 
-    expect(responseData.summary.totalSpans).toBe(3);
-    expect(responseData.summary.filteredTotalSpans).toBe(3);
-    expect(responseData.summary.returnedSpans).toBe(1);
     expect(responseData.spans).toHaveLength(1);
     expect(responseData.summary.pageInfo.totalPages).toBe(3);
     expect(responseData.summary.pageInfo.currentPage).toBe(2);
@@ -351,9 +336,6 @@ describe("Trace Tool", () => {
 
     const responseData = JSON.parse(result.content[0].text as string);
 
-    expect(responseData.summary.totalSpans).toBe(3);
-    expect(responseData.summary.filteredTotalSpans).toBe(3);
-    expect(responseData.summary.returnedSpans).toBe(0);
     expect(responseData.spans).toHaveLength(0);
     expect(responseData.summary.pageInfo.totalPages).toBe(1);
     expect(responseData.summary.pageInfo.currentPage).toBe(11);
@@ -388,9 +370,6 @@ describe("Trace Tool", () => {
 
     const responseData = JSON.parse(result.content[0].text as string);
 
-    expect(responseData.summary.totalSpans).toBe(3);
-    expect(responseData.summary.filteredTotalSpans).toBe(2); // 2 spans with duration >= 400ms
-    expect(responseData.summary.returnedSpans).toBe(1);
     expect(responseData.spans).toHaveLength(1);
     expect(responseData.summary.pageInfo.totalPages).toBe(2);
     expect(responseData.summary.pageInfo.currentPage).toBe(1);

--- a/src/tools/traceTool.test.ts
+++ b/src/tools/traceTool.test.ts
@@ -100,6 +100,7 @@ describe("Trace Tool", () => {
     const responseData = JSON.parse(result.content[0].text as string);
 
     expect(responseData.traceId).toBe("trace123");
+    expect(responseData.summary.totalSpans).toBe(3);
     expect(responseData.summary.hasErrors).toBe(true);
     expect(responseData.summary.pageInfo.totalPages).toBe(1);
     expect(responseData.summary.pageInfo.currentPage).toBe(1);
@@ -141,6 +142,7 @@ describe("Trace Tool", () => {
 
     const responseData = JSON.parse(result.content[0].text as string);
 
+    expect(responseData.summary.totalSpans).toBe(3);
     expect(responseData.spans).toHaveLength(2);
 
     // Should include the 500ms and 600ms spans, but not the 30ms cache span
@@ -174,6 +176,7 @@ describe("Trace Tool", () => {
 
     const responseData = JSON.parse(result.content[0].text as string);
 
+    expect(responseData.summary.totalSpans).toBe(3);
     expect(responseData.spans).toHaveLength(1);
     expect(responseData.spans[0].spanId).toBe("span2");
     expect(responseData.spans[0].hasError).toBe(true);
@@ -263,6 +266,7 @@ describe("Trace Tool", () => {
 
     const responseData = JSON.parse(result.content[0].text as string);
 
+    expect(responseData.summary.totalSpans).toBe(3);
     expect(responseData.spans).toHaveLength(2);
     expect(responseData.summary.pageInfo.totalPages).toBe(2);
     expect(responseData.summary.pageInfo.currentPage).toBe(1);
@@ -300,6 +304,7 @@ describe("Trace Tool", () => {
 
     const responseData = JSON.parse(result.content[0].text as string);
 
+    expect(responseData.summary.totalSpans).toBe(3);
     expect(responseData.spans).toHaveLength(1);
     expect(responseData.summary.pageInfo.totalPages).toBe(3);
     expect(responseData.summary.pageInfo.currentPage).toBe(2);
@@ -336,6 +341,7 @@ describe("Trace Tool", () => {
 
     const responseData = JSON.parse(result.content[0].text as string);
 
+    expect(responseData.summary.totalSpans).toBe(3);
     expect(responseData.spans).toHaveLength(0);
     expect(responseData.summary.pageInfo.totalPages).toBe(1);
     expect(responseData.summary.pageInfo.currentPage).toBe(11);
@@ -370,6 +376,7 @@ describe("Trace Tool", () => {
 
     const responseData = JSON.parse(result.content[0].text as string);
 
+    expect(responseData.summary.totalSpans).toBe(3);
     expect(responseData.spans).toHaveLength(1);
     expect(responseData.summary.pageInfo.totalPages).toBe(2);
     expect(responseData.summary.pageInfo.currentPage).toBe(1);

--- a/src/tools/traceTool.ts
+++ b/src/tools/traceTool.ts
@@ -123,7 +123,7 @@ export class TraceTool {
       optimized.events = span.events;
     }
 
-    if (span.status && (span.status.code !== "OK" || span.status.message)) {
+    if (span.status && span.status.code.toLowerCase() === "error") {
       optimized.status = span.status;
     }
 

--- a/src/tools/traceTool.ts
+++ b/src/tools/traceTool.ts
@@ -216,9 +216,6 @@ export class TraceTool {
       const paginatedSpans = applyPagination(filteredSpans, { limit, offset });
       const pageInfo = this.createPageInfo(filteredSpans.length, limit, offset);
 
-      const totalSpans = response.spans.length;
-      const filteredTotalSpans = filteredSpans.length;
-      const returnedSpans = paginatedSpans.length;
       const hasErrors = paginatedSpans.some(
         (span: OptimizedSpan) => span.hasError,
       );
@@ -236,20 +233,9 @@ export class TraceTool {
       return {
         traceId,
         summary: {
-          totalSpans,
-          filteredTotalSpans,
-          returnedSpans,
           hasErrors,
           totalDuration,
           pageInfo,
-          filters: {
-            includeAttributes,
-            includeEvents,
-            limit,
-            offset,
-            filterByDuration,
-            errorSpansOnly,
-          },
         },
         spans: paginatedSpans,
       };

--- a/src/tools/traceTool.ts
+++ b/src/tools/traceTool.ts
@@ -159,6 +159,8 @@ export class TraceTool {
       filtered = filtered.filter((span) => span.duration >= duration);
     }
 
+    // Sort spans by priority: error spans first, then by duration (longest first)
+    // This ensures critical issues (errors) and performance bottlenecks (slow spans) are surfaced at the top
     filtered.sort((a, b) => {
       if (a.hasError && !b.hasError) return -1;
       if (!a.hasError && b.hasError) return 1;

--- a/src/tools/traceTool.ts
+++ b/src/tools/traceTool.ts
@@ -131,15 +131,9 @@ export class TraceTool {
   }
 
   private hasSpanError(span: TraceSpan): boolean {
-    if (span.status && span.status.code === "ERROR (2)") {
-      return true;
-    }
-
     if (span.events) {
-      return span.events.some(
-        (event) =>
-          event.name.toLowerCase().includes("error") ||
-          event.name.toLowerCase().includes("exception"),
+      return span.events.some((event) =>
+        event.name.toLowerCase().includes("exception"),
       );
     }
 

--- a/src/tools/traceTool.ts
+++ b/src/tools/traceTool.ts
@@ -82,7 +82,7 @@ export class TraceTool {
       .optional()
       .default(0)
       .describe("Number of spans to skip (default: 0)"),
-    filterByDuration: z
+    duration: z
       .number()
       .min(0)
       .optional()
@@ -142,7 +142,7 @@ export class TraceTool {
 
   private filterAndSortSpans(
     spans: OptimizedSpan[],
-    filterByDuration?: number,
+    duration?: number,
     errorSpansOnly?: boolean,
   ): OptimizedSpan[] {
     let filtered = spans;
@@ -151,8 +151,8 @@ export class TraceTool {
       filtered = filtered.filter((span) => span.hasError);
     }
 
-    if (filterByDuration !== undefined) {
-      filtered = filtered.filter((span) => span.duration >= filterByDuration);
+    if (duration !== undefined) {
+      filtered = filtered.filter((span) => span.duration >= duration);
     }
 
     filtered.sort((a, b) => {
@@ -191,7 +191,7 @@ export class TraceTool {
     includeEvents = true,
     limit = 20,
     offset = 0,
-    filterByDuration,
+    duration,
     errorSpansOnly = false,
   }: z.infer<typeof TraceTool.GetTraceToolInput>) => {
     return await buildToolResponse(async () => {
@@ -203,7 +203,7 @@ export class TraceTool {
 
       const filteredSpans = this.filterAndSortSpans(
         optimizedSpans,
-        filterByDuration,
+        duration,
         errorSpansOnly,
       );
 

--- a/src/tools/traceTool.ts
+++ b/src/tools/traceTool.ts
@@ -115,7 +115,7 @@ export class TraceTool {
       hasError,
     };
 
-    if (includeAttributes && span.attributes) {
+    if (includeAttributes) {
       optimized.attributes = span.attributes;
     }
 

--- a/src/tools/traceTool.ts
+++ b/src/tools/traceTool.ts
@@ -1,0 +1,211 @@
+import { z } from "zod";
+import { MackerelClient } from "../client.js";
+import { buildToolResponse } from "./util.js";
+
+interface TraceSpan {
+  traceId: string;
+  spanId: string;
+  name: string;
+  startTime: number;
+  endTime: number;
+  duration?: number;
+  attributes?: Record<string, any>;
+  events?: Array<{
+    name: string;
+    timestamp: number;
+    attributes?: Record<string, any>;
+  }>;
+  status?: {
+    code: string;
+    message?: string;
+  };
+  resource?: Record<string, any>;
+  scope?: Record<string, any>;
+}
+
+interface OptimizedSpan {
+  spanId: string;
+  name: string;
+  startTime: number;
+  endTime: number;
+  duration: number;
+  attributes?: Record<string, any>;
+  events?: Array<{
+    name: string;
+    timestamp: number;
+    attributes?: Record<string, any>;
+  }>;
+  status?: {
+    code: string;
+    message?: string;
+  };
+  hasError?: boolean;
+}
+
+export class TraceTool {
+  constructor(private mackerelClient: MackerelClient) {}
+
+  static GetTraceToolInput = z.object({
+    traceId: z.string().describe("The ID of the trace to retrieve"),
+    includeAttributes: z
+      .boolean()
+      .optional()
+      .default(false)
+      .describe(
+        "Whether to include span attributes. Default is false to reduce response size",
+      ),
+    includeEvents: z
+      .boolean()
+      .optional()
+      .default(true)
+      .describe(
+        "Whether to include span events. Default is true as events contain important error information",
+      ),
+    maxSpans: z
+      .number()
+      .min(1)
+      .max(1000)
+      .optional()
+      .default(100)
+      .describe(
+        "Maximum number of spans to return. Default is 100 to manage response size",
+      ),
+    filterByDuration: z
+      .number()
+      .min(0)
+      .optional()
+      .describe(
+        "Only return spans with duration (in milliseconds) equal to or greater than this value. Useful for identifying bottlenecks",
+      ),
+    errorSpansOnly: z
+      .boolean()
+      .optional()
+      .default(false)
+      .describe(
+        "If true, only return spans that have errors or status code indicating failure",
+      ),
+  });
+
+  private optimizeSpan(
+    span: TraceSpan,
+    includeAttributes: boolean,
+    includeEvents: boolean,
+  ): OptimizedSpan {
+    const duration = span.endTime - span.startTime;
+    const hasError = this.hasSpanError(span);
+
+    const optimized: OptimizedSpan = {
+      spanId: span.spanId,
+      name: span.name,
+      startTime: span.startTime,
+      endTime: span.endTime,
+      duration,
+      hasError,
+    };
+
+    if (includeAttributes && span.attributes) {
+      optimized.attributes = span.attributes;
+    }
+
+    if (includeEvents && span.events && span.events.length > 0) {
+      optimized.events = span.events;
+    }
+
+    if (span.status && (span.status.code !== "OK" || span.status.message)) {
+      optimized.status = span.status;
+    }
+
+    return optimized;
+  }
+
+  private hasSpanError(span: TraceSpan): boolean {
+    if (span.status && span.status.code !== "OK") {
+      return true;
+    }
+
+    if (span.events) {
+      return span.events.some(
+        (event) =>
+          event.name.toLowerCase().includes("error") ||
+          event.name.toLowerCase().includes("exception"),
+      );
+    }
+
+    return false;
+  }
+
+  private filterSpans(
+    spans: OptimizedSpan[],
+    maxSpans: number,
+    filterByDuration?: number,
+    errorSpansOnly?: boolean,
+  ): OptimizedSpan[] {
+    let filtered = spans;
+
+    if (errorSpansOnly) {
+      filtered = filtered.filter((span) => span.hasError);
+    }
+
+    if (filterByDuration !== undefined) {
+      filtered = filtered.filter((span) => span.duration >= filterByDuration);
+    }
+
+    filtered.sort((a, b) => {
+      if (a.hasError && !b.hasError) return -1;
+      if (!a.hasError && b.hasError) return 1;
+      return b.duration - a.duration;
+    });
+
+    return filtered.slice(0, maxSpans);
+  }
+
+  getTrace = async ({
+    traceId,
+    includeAttributes = false,
+    includeEvents = true,
+    maxSpans = 100,
+    filterByDuration,
+    errorSpansOnly = false,
+  }: z.infer<typeof TraceTool.GetTraceToolInput>) => {
+    return await buildToolResponse(async () => {
+      const response = await this.mackerelClient.getTrace(traceId);
+
+      const optimizedSpans = response.spans.map((span: TraceSpan) =>
+        this.optimizeSpan(span, includeAttributes, includeEvents),
+      );
+
+      const filteredSpans = this.filterSpans(
+        optimizedSpans,
+        maxSpans,
+        filterByDuration,
+        errorSpansOnly,
+      );
+
+      const totalSpans = response.spans.length;
+      const returnedSpans = filteredSpans.length;
+      const hasErrors = filteredSpans.some((span) => span.hasError);
+
+      const traceStartTime = Math.min(...filteredSpans.map((s) => s.startTime));
+      const traceEndTime = Math.max(...filteredSpans.map((s) => s.endTime));
+      const totalDuration = traceEndTime - traceStartTime;
+
+      return {
+        traceId,
+        summary: {
+          totalSpans,
+          returnedSpans,
+          hasErrors,
+          totalDuration,
+          filters: {
+            includeAttributes,
+            includeEvents,
+            maxSpans,
+            filterByDuration,
+            errorSpansOnly,
+          },
+        },
+        spans: filteredSpans,
+      };
+    });
+  };
+}

--- a/src/tools/traceTool.ts
+++ b/src/tools/traceTool.ts
@@ -131,6 +131,10 @@ export class TraceTool {
   }
 
   private hasSpanError(span: TraceSpan): boolean {
+    if (span.status && span.status.code.toLowerCase() === "error") {
+      return true;
+    }
+
     if (span.events) {
       return span.events.some((event) =>
         event.name.toLowerCase().includes("exception"),

--- a/src/tools/traceTool.ts
+++ b/src/tools/traceTool.ts
@@ -223,11 +223,11 @@ export class TraceTool {
 
       let totalDuration = 0;
 
-      if (filteredSpans.length > 0) {
+      if (optimizedSpans.length > 0) {
         const traceStartTime = Math.min(
-          ...filteredSpans.map((s) => s.startTime),
+          ...optimizedSpans.map((s) => s.startTime),
         );
-        const traceEndTime = Math.max(...filteredSpans.map((s) => s.endTime));
+        const traceEndTime = Math.max(...optimizedSpans.map((s) => s.endTime));
         totalDuration = traceEndTime - traceStartTime;
       }
 

--- a/src/tools/traceTool.ts
+++ b/src/tools/traceTool.ts
@@ -119,7 +119,7 @@ export class TraceTool {
       optimized.attributes = span.attributes;
     }
 
-    if (includeEvents && span.events && span.events.length > 0) {
+    if (includeEvents) {
       optimized.events = span.events;
     }
 

--- a/src/tools/traceTool.ts
+++ b/src/tools/traceTool.ts
@@ -219,13 +219,13 @@ export class TraceTool {
         (span: OptimizedSpan) => span.hasError,
       );
 
-      let traceStartTime = 0;
-      let traceEndTime = 0;
       let totalDuration = 0;
 
-      if (paginatedSpans.length > 0) {
-        traceStartTime = Math.min(...paginatedSpans.map((s) => s.startTime));
-        traceEndTime = Math.max(...paginatedSpans.map((s) => s.endTime));
+      if (filteredSpans.length > 0) {
+        const traceStartTime = Math.min(
+          ...filteredSpans.map((s) => s.startTime),
+        );
+        const traceEndTime = Math.max(...filteredSpans.map((s) => s.endTime));
         totalDuration = traceEndTime - traceStartTime;
       }
 

--- a/src/tools/traceTool.ts
+++ b/src/tools/traceTool.ts
@@ -216,6 +216,7 @@ export class TraceTool {
       const paginatedSpans = applyPagination(filteredSpans, { limit, offset });
       const pageInfo = this.createPageInfo(filteredSpans.length, limit, offset);
 
+      const totalSpans = response.spans.length;
       const hasErrors = paginatedSpans.some(
         (span: OptimizedSpan) => span.hasError,
       );
@@ -233,6 +234,7 @@ export class TraceTool {
       return {
         traceId,
         summary: {
+          totalSpans,
           hasErrors,
           totalDuration,
           pageInfo,

--- a/src/tools/traceTool.ts
+++ b/src/tools/traceTool.ts
@@ -127,7 +127,7 @@ export class TraceTool {
   }
 
   private hasSpanError(span: TraceSpan): boolean {
-    if (span.status && span.status.code !== "OK") {
+    if (span.status && span.status.code === "ERROR (2)") {
       return true;
     }
 


### PR DESCRIPTION
This PR implements a new get_trace tool for retrieving distributed tracing data from Mackerel API.

Iimplemented filtering and pagination to reduce the context size.

  - Filtering Options:
    - errorSpansOnly: Show only spans with errors
    - filterByDuration: Filter by minimum duration (ms)
    - includeAttributes: Control attribute inclusion for response size
    - includeEvents: Control event inclusion (default: true for error analysis)

## Use Cases

  1. Error Analysis: Quickly identify error propagation across microservices
  2. Performance Investigation: Find bottlenecks and slow operations
  3. Service Dependencies: Understand request flows and system architecture
  4. Interactive Analysis: Progressive drill-down with pagination
  5. Documentation Generation: Dynamic system architecture documentation

## API Examples

```
  // Basic trace retrieval
  get_trace(traceId="abc123")

  // Error-focused analysis
  get_trace(traceId="abc123", errorSpansOnly=true)

  // Performance analysis
  get_trace(traceId="abc123", filterByDuration=100)

  // Pagination through large traces
  get_trace(traceId="abc123", limit=20, offset=0)  // First page
  get_trace(traceId="abc123", limit=20, offset=20) // Second page
```