### PR TITLE
ignore-scripts=true

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true


### PR DESCRIPTION
As a supply chain security measure, we disable scripts run during postinstall. This change does not affect any existing dependencies.