### PR TITLE
Use npm@11 for node tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,26 +4,6 @@ on:
   push:
 
 jobs:
-  test:
-    name: Node Tests
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [22.x, 20.x]
-
-    steps:
-    - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-      with:
-        node-version: ${{ matrix.node-version }}
-
-    - run: npm ci
-    - run: npm run build
-    - run: npm run format:check
-    - run: npm run test
-
   test_latest:
     name: Node Test for Latest
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,29 @@ on:
   push:
 
 jobs:
+  test:
+    name: Node Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [22.x, 20.x]
+
+    steps:
+    - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Install npm 11.x
+      run: npm install -g npm@11
+
+    - run: npm ci
+    - run: npm run build
+    - run: npm run format:check
+    - run: npm run test
+
   test_latest:
     name: Node Test for Latest
     runs-on: ubuntu-latest


### PR DESCRIPTION
Upgrade npm to 11.x in the CI test job so that npm ci stays consistent with the Dependabot-generated lock file, while keeping the existing Node 20.x / 22.x runtime matrix.